### PR TITLE
Design model associations fix

### DIFF
--- a/PhotoKingdomAPI/PhotoKingdomAPI/Controllers/Manager.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Controllers/Manager.cs
@@ -48,8 +48,8 @@ namespace PhotoKingdomAPI.Controllers
                 cfg.CreateMap<Controllers.CountryPhotowarAdd, Models.CountryPhotowar>();
                 cfg.CreateMap<Models.CountryPhotowarPhotorequest, Controllers.CountryPhotowarPhotorequestBase>();
                 cfg.CreateMap<Controllers.CountryPhotowarPhotorequestAdd, Models.CountryPhotowarPhotorequest>();
-                cfg.CreateMap<Models.CountryPhotowarRequestdphotoUpload, Controllers.CountryPhotowarRequestdphotoUploadBase>();
-                cfg.CreateMap<Controllers.CountryPhotowarRequestdphotoUploadAdd, Models.CountryPhotowarRequestdphotoUpload>();
+                cfg.CreateMap<Models.CountryPhotowarRequestedphotoUpload, Controllers.CountryPhotowarRequestdphotoUploadBase>();
+                cfg.CreateMap<Controllers.CountryPhotowarRequestdphotoUploadAdd, Models.CountryPhotowarRequestedphotoUpload>();
                 cfg.CreateMap<Models.CountryPhotowarUpload, Controllers.CountryPhotowarUploadBase>();
                 cfg.CreateMap<Controllers.CountryPhotowarUploadAdd, Models.CountryPhotowarUpload>();
                 cfg.CreateMap<Models.CountryProfile, Controllers.CountryProfileBase>();
@@ -74,12 +74,12 @@ namespace PhotoKingdomAPI.Controllers
                 cfg.CreateMap<Controllers.ResidentCountryOwnAdd, Models.ResidentCountryOwn>();
                 cfg.CreateMap<Models.ResidentProvinceOwn, Controllers.ResidentProvinceOwnBase>();
                 cfg.CreateMap<Controllers.ResidentProvinceOwnAdd, Models.ResidentProvinceOwn>();
-                cfg.CreateMap<Models.VoteAttractionPhotowarUpload, Controllers.VoteAttractionPhotowarUploadBase>();
-                cfg.CreateMap<Controllers.VoteAttractionPhotowarUploadAdd, Models.VoteAttractionPhotowarUpload>();
-                cfg.CreateMap<Models.VoteContinentPhotowarUpload, Controllers.VoteContinentPhotowarUploadBase>();
-                cfg.CreateMap<Controllers.VoteContinentPhotowarUploadAdd, Models.VoteContinentPhotowarUpload>();
-                cfg.CreateMap<Models.VoteCountryPhotowarUpload, Controllers.VoteCountryPhotowarUploadBase>();
-                cfg.CreateMap< Controllers.VoteCountryPhotowarUploadAdd, Models.VoteCountryPhotowarUpload >();
+                //cfg.CreateMap<Models.VoteAttractionPhotowarUpload, Controllers.VoteAttractionPhotowarUploadBase>();
+                //cfg.CreateMap<Controllers.VoteAttractionPhotowarUploadAdd, Models.VoteAttractionPhotowarUpload>();
+                //cfg.CreateMap<Models.VoteContinentPhotowarUpload, Controllers.VoteContinentPhotowarUploadBase>();
+                //cfg.CreateMap<Controllers.VoteContinentPhotowarUploadAdd, Models.VoteContinentPhotowarUpload>();
+                //cfg.CreateMap<Models.VoteCountryPhotowarUpload, Controllers.VoteCountryPhotowarUploadBase>();
+                //cfg.CreateMap< Controllers.VoteCountryPhotowarUploadAdd, Models.VoteCountryPhotowarUpload >();
             });
 
             mapper = config.CreateMapper();
@@ -97,5 +97,18 @@ namespace PhotoKingdomAPI.Controllers
         }
 
         // TODO: Need to implement CRUD methods
+
+
+        // **************************************************************
+        //                          Attraction
+        // **************************************************************
+
+        public IEnumerable<AttractionBase> AttractionGetAll()
+        {
+            return mapper.Map<IEnumerable<Attraction>, IEnumerable<AttractionBase>>(ds.Attractions);
+        }
+
+        
+
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Attraction.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Attraction.cs
@@ -8,6 +8,13 @@ namespace PhotoKingdomAPI.Models
 {
     public class Attraction
     {
+        public Attraction()
+        {
+            QueuedUploads = new List<Queue>();
+            AttractionPhotowars = new List<AttractionPhotowar>();
+            Owners = new List<ResidentAttractionOwn>();
+        }
+
         public int Id { get; set; }
 
         [Required]
@@ -24,7 +31,16 @@ namespace PhotoKingdomAPI.Models
         public int IsActive { get; set; }
 
         [Required]
-        //public int CityId { get; set; }
+        public int CityId { get; set; }
+
+        // navigations
+
         public City City { get; set; }
+        // the queued photo uploads for this Attraction
+        public ICollection<Queue> QueuedUploads { get; set; }
+        // all the AttractionPhotowars for this Attraction
+        public ICollection<AttractionPhotowar> AttractionPhotowars { get; set; }
+        // all the residents that owned this Attraction
+        public ICollection<ResidentAttractionOwn> Owners { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Attraction.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Attraction.cs
@@ -24,6 +24,7 @@ namespace PhotoKingdomAPI.Models
         public int IsActive { get; set; }
 
         [Required]
-        public int CityId { get; set; }
+        //public int CityId { get; set; }
+        public City City { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/AttractionPhotowar.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/AttractionPhotowar.cs
@@ -17,6 +17,7 @@ namespace PhotoKingdomAPI.Models
         public DateTime EndDate { get; set; }
 
         [Required]
-        public int AttractionId { get; set; }
+        //public int AttractionId { get; set; }
+        public Attraction Attraction { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/AttractionPhotowar.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/AttractionPhotowar.cs
@@ -8,6 +8,11 @@ namespace PhotoKingdomAPI.Models
 {
     public class AttractionPhotowar
     {
+        public AttractionPhotowar()
+        {
+            AttractionPhotowarUploads = new List<AttractionPhotowarUpload>();
+        }
+
         public int Id { get; set; }
 
         [Required]
@@ -17,7 +22,12 @@ namespace PhotoKingdomAPI.Models
         public DateTime EndDate { get; set; }
 
         [Required]
-        //public int AttractionId { get; set; }
+        public int AttractionId { get; set; }
+
+        // navigations
+
         public Attraction Attraction { get; set; }
+        // the two photos uploaded for this PhotoWar
+        public ICollection<AttractionPhotowarUpload> AttractionPhotowarUploads { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/AttractionPhotowarUpload.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/AttractionPhotowarUpload.cs
@@ -15,9 +15,14 @@ namespace PhotoKingdomAPI.Models
         public int IsLoser { get; set; }
 
         [Required]
-        public int PhotoId { get; set; }
-
+        //public int PhotoId { get; set; }
+        public Photo Photo { get; set; }
+        
         [Required]
-        public int AttractionPhotowarId { get; set; }
+        //public int AttractionPhotowarId { get; set; }
+        public AttractionPhotowar AttractionPhotoWar { get; set; }
+
+        // Votes
+        public ICollection<Resident> ResidentVote { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/AttractionPhotowarUpload.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/AttractionPhotowarUpload.cs
@@ -8,6 +8,11 @@ namespace PhotoKingdomAPI.Models
 {
     public class AttractionPhotowarUpload
     {
+        public AttractionPhotowarUpload()
+        {
+            ResidentVotes = new List<Resident>();
+        }
+
         public int Id { get; set; }
 
         public int IsWinner { get; set; }
@@ -15,14 +20,16 @@ namespace PhotoKingdomAPI.Models
         public int IsLoser { get; set; }
 
         [Required]
-        //public int PhotoId { get; set; }
-        public Photo Photo { get; set; }
+        public int PhotoId { get; set; }
         
         [Required]
-        //public int AttractionPhotowarId { get; set; }
-        public AttractionPhotowar AttractionPhotoWar { get; set; }
+        public int AttractionPhotowarId { get; set; }
 
-        // Votes
-        public ICollection<Resident> ResidentVote { get; set; }
+        // navigations
+
+        public Photo Photo { get; set; }
+        public AttractionPhotowar AttractionPhotoWar { get; set; }
+        // all the votes for this Photo
+        public ICollection<Resident> ResidentVotes { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/City.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/City.cs
@@ -15,9 +15,10 @@ namespace PhotoKingdomAPI.Models
         public string Name { get; set; }
 
         [Required]
-        public int CountryId { get; set; }
+        //public int CountryId { get; set; }
+        public Country Country { get; set; }
 
-        [Required]
-        public int ProvinceId { get; set; }
+        //public int ProvinceId { get; set; }
+        public Province Province { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/City.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/City.cs
@@ -8,6 +8,11 @@ namespace PhotoKingdomAPI.Models
 {
     public class City
     {
+        public City()
+        {
+            Owners = new List<ResidentCityOwn>();
+        }
+
         public int Id { get; set; }
 
         [Required]
@@ -15,10 +20,15 @@ namespace PhotoKingdomAPI.Models
         public string Name { get; set; }
 
         [Required]
-        //public int CountryId { get; set; }
-        public Country Country { get; set; }
+        public int CountryId { get; set; }
 
-        //public int ProvinceId { get; set; }
+        public int? ProvinceId { get; set; } // province is optional
+
+        // navigations
+
+        public Country Country { get; set; }
         public Province Province { get; set; }
+        // all the residents that owned this City
+        public ICollection<ResidentCityOwn> Owners { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Continent.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Continent.cs
@@ -8,10 +8,19 @@ namespace PhotoKingdomAPI.Models
 {
     public class Continent
     {
+        public Continent()
+        {
+            Owners = new List<ResidentContinentOwn>();
+        }
+
         public int Id { get; set; }
 
         [Required]
         [StringLength(20)]
         public string Name { get; set; }
+
+        // navigation
+        // all the residents that owned this Continent
+        public ICollection<ResidentContinentOwn> Owners { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowar.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowar.cs
@@ -26,11 +26,13 @@ namespace PhotoKingdomAPI.Models
         public int IsCancelled { get; set; }
 
         [Required]
-        [ForeignKey("ContinentProfile")]
-        public int DeclaringContinentId { get; set; }
+        /*[ForeignKey("ContinentProfile")]
+        public int DeclaringContinentId { get; set; }*/
+        public ContinentProfile DeclaringContinent { get; set; }
 
         [Required]
-        [ForeignKey("ContinentProfile")]
-        public int RecipentContinentId { get; set; }
+        /*[ForeignKey("ContinentProfile")]
+        public int RecipentContinentId { get; set; }*/
+        public ContinentProfile RecipientContinent { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowar.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowar.cs
@@ -9,6 +9,11 @@ namespace PhotoKingdomAPI.Models
 {
     public class ContinentPhotowar
     {
+        public ContinentPhotowar()
+        {
+            ContinentPhotowarUploads = new List<ContinentPhotowarUpload>();
+        }
+
         public int Id { get; set; }
 
         [Required]
@@ -26,13 +31,18 @@ namespace PhotoKingdomAPI.Models
         public int IsCancelled { get; set; }
 
         [Required]
-        /*[ForeignKey("ContinentProfile")]
-        public int DeclaringContinentId { get; set; }*/
-        public ContinentProfile DeclaringContinent { get; set; }
+        [ForeignKey("ContinentProfile")]
+        public int DeclaringContinentId { get; set; }
 
         [Required]
-        /*[ForeignKey("ContinentProfile")]
-        public int RecipentContinentId { get; set; }*/
+        [ForeignKey("ContinentProfile")]
+        public int RecipentContinentId { get; set; }
+
+        // navigations
+
+        public ContinentProfile DeclaringContinent { get; set; }
         public ContinentProfile RecipientContinent { get; set; }
+        // the two photos uploaded for this photowar
+        public ICollection<ContinentPhotowarUpload> ContinentPhotowarUploads { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowarPhotorequest.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowarPhotorequest.cs
@@ -19,14 +19,17 @@ namespace PhotoKingdomAPI.Models
         public DateTime DenialDate { get; set; }
 
         [Required]
-        public int ContinentPhotowarId { get; set; }
+        //public int ContinentPhotowarId { get; set; }
+        public ContinentPhotowar ContinentPhotoWar { get; set; }
 
         [Required]
-        [ForeignKey("Resident")]
-        public int RequestingResidentId { get; set; }
-
+        /*[ForeignKey("Resident")]
+        public int RequestingResidentId { get; set; }*/
+        public Resident RequestingResident { get; set; }
+        
         [Required]
-        [ForeignKey("Resident")]
-        public int RecipientResidentId { get; set; }
+        /*[ForeignKey("Resident")]
+        public int RecipientResidentId { get; set; }*/
+        public Resident RecipientResident { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowarPhotorequest.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowarPhotorequest.cs
@@ -19,17 +19,19 @@ namespace PhotoKingdomAPI.Models
         public DateTime DenialDate { get; set; }
 
         [Required]
-        //public int ContinentPhotowarId { get; set; }
-        public ContinentPhotowar ContinentPhotoWar { get; set; }
+        public int ContinentPhotowarId { get; set; }
 
         [Required]
-        /*[ForeignKey("Resident")]
-        public int RequestingResidentId { get; set; }*/
-        public Resident RequestingResident { get; set; }
+        [ForeignKey("Resident")]
+        public int RequestingResidentId { get; set; }
         
         [Required]
-        /*[ForeignKey("Resident")]
-        public int RecipientResidentId { get; set; }*/
+        [ForeignKey("Resident")]
+        public int RecipientResidentId { get; set; }
+
+        // navigations
+        public ContinentPhotowar ContinentPhotoWar { get; set; }
+        public Resident RequestingResident { get; set; }
         public Resident RecipientResident { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowarRequestedphotoUpload.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowarRequestedphotoUpload.cs
@@ -14,9 +14,11 @@ namespace PhotoKingdomAPI.Models
         public int IsChosenCompetitor { get; set; }
 
         [Required]
-        public int PhotoId { get; set; }
+        //public int PhotoId { get; set; }
+        public Photo Photo { get; set; }
 
         [Required]
-        public int ContinentPhotowarPhotorequestId { get; set; }
+        //public int ContinentPhotowarPhotorequestId { get; set; }
+        public ContinentPhotowarPhotorequest ContinentPhotoWarPhotorequest { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowarRequestedphotoUpload.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowarRequestedphotoUpload.cs
@@ -14,11 +14,13 @@ namespace PhotoKingdomAPI.Models
         public int IsChosenCompetitor { get; set; }
 
         [Required]
-        //public int PhotoId { get; set; }
-        public Photo Photo { get; set; }
+        public int PhotoId { get; set; }
 
         [Required]
-        //public int ContinentPhotowarPhotorequestId { get; set; }
+        public int ContinentPhotowarPhotorequestId { get; set; }
+
+        // navigations
+        public Photo Photo { get; set; }
         public ContinentPhotowarPhotorequest ContinentPhotoWarPhotorequest { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowarUpload.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowarUpload.cs
@@ -15,9 +15,14 @@ namespace PhotoKingdomAPI.Models
         public int IsLoser { get; set; }
 
         [Required]
-        public int PhotoId { get; set; }
-
+        //public int PhotoId { get; set; }
+        public Photo Photo { get; set; }
+        
         [Required]
-        public int ContinentPhotowarId { get; set; }
+        //public int ContinentPhotowarId { get; set; }
+        public ContinentPhotowar ContinentPhotowar { get; set; }
+
+        // Votes
+        public ICollection<Resident> ResidentVote { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowarUpload.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentPhotowarUpload.cs
@@ -8,6 +8,11 @@ namespace PhotoKingdomAPI.Models
 {
     public class ContinentPhotowarUpload
     {
+        public ContinentPhotowarUpload()
+        {
+            ResidentVotes = new List<Resident>();
+        }
+
         public int Id { get; set; }
 
         public int IsWinner { get; set; }
@@ -15,14 +20,16 @@ namespace PhotoKingdomAPI.Models
         public int IsLoser { get; set; }
 
         [Required]
-        //public int PhotoId { get; set; }
-        public Photo Photo { get; set; }
+        public int PhotoId { get; set; }
         
         [Required]
-        //public int ContinentPhotowarId { get; set; }
-        public ContinentPhotowar ContinentPhotowar { get; set; }
+        public int ContinentPhotowarId { get; set; }
 
-        // Votes
-        public ICollection<Resident> ResidentVote { get; set; }
+        // navigations
+
+        public Photo Photo { get; set; }
+        public ContinentPhotowar ContinentPhotowar { get; set; }
+        // Votes for this ContinentPhotowar
+        public ICollection<Resident> ResidentVotes { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentProfile.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentProfile.cs
@@ -11,9 +11,11 @@ namespace PhotoKingdomAPI.Models
         public int Id { get; set; }
 
         [Required]
-        public int ContinentId { get; set; }
-
+        //public int ContinentId { get; set; }
+        public Continent Continent { get; set; }
+        
         [Required]
-        public int PhotoId { get; set; }
+        //public int PhotoId { get; set; }
+        public Photo Photo { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentProfile.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ContinentProfile.cs
@@ -11,11 +11,13 @@ namespace PhotoKingdomAPI.Models
         public int Id { get; set; }
 
         [Required]
-        //public int ContinentId { get; set; }
-        public Continent Continent { get; set; }
+        public int ContinentId { get; set; }
         
         [Required]
-        //public int PhotoId { get; set; }
+        public int PhotoId { get; set; }
+
+        // navigations
+        public Continent Continent { get; set; }
         public Photo Photo { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Country.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Country.cs
@@ -8,6 +8,11 @@ namespace PhotoKingdomAPI.Models
 {
     public class Country
     {
+        public Country()
+        {
+            Owners = new List<ResidentCountryOwn>();
+        }
+
         public int Id { get; set; }
 
         [Required]
@@ -15,7 +20,12 @@ namespace PhotoKingdomAPI.Models
         public string Name { get; set; }
 
         [Required]
-        //public int ContinentId { get; set; }
+        public int ContinentId { get; set; }
+
+        // navigation
+
         public Continent Continent { get; set; }
+        // all the residents that owned this country
+        public ICollection<ResidentCountryOwn> Owners { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Country.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Country.cs
@@ -15,6 +15,7 @@ namespace PhotoKingdomAPI.Models
         public string Name { get; set; }
 
         [Required]
-        public int ContinentId { get; set; }
+        //public int ContinentId { get; set; }
+        public Continent Continent { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowar.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowar.cs
@@ -9,6 +9,11 @@ namespace PhotoKingdomAPI.Models
 {
     public class CountryPhotowar
     {
+        public CountryPhotowar()
+        {
+            CountryPhotowarUploads = new List<CountryPhotowarUpload>();
+        }
+
         public int Id { get; set; }
 
         [Required]
@@ -26,13 +31,18 @@ namespace PhotoKingdomAPI.Models
         public int IsCancelled { get; set; }
 
         [Required]
-        /*[ForeignKey("CountryProfile")]
-        public int DeclaringCountryId { get; set; }*/
-        public CountryProfile DeclaringCountry { get; set; }
+        [ForeignKey("CountryProfile")]
+        public int DeclaringCountryId { get; set; }
 
         [Required]
-        /*[ForeignKey("CountryProfile")]
-        public int RecipentCountryId { get; set; }*/
+        [ForeignKey("CountryProfile")]
+        public int RecipentCountryId { get; set; }
+
+        // navigations
+
+        public CountryProfile DeclaringCountry { get; set; }
         public CountryProfile RecipientCountry { get; set; }
+        // the two photos uploaded for this photowar
+        public ICollection<CountryPhotowarUpload> CountryPhotowarUploads { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowar.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowar.cs
@@ -26,11 +26,13 @@ namespace PhotoKingdomAPI.Models
         public int IsCancelled { get; set; }
 
         [Required]
-        [ForeignKey("CountryProfile")]
-        public int DeclaringCountryId { get; set; }
+        /*[ForeignKey("CountryProfile")]
+        public int DeclaringCountryId { get; set; }*/
+        public CountryProfile DeclaringCountry { get; set; }
 
         [Required]
-        [ForeignKey("CountryProfile")]
-        public int RecipentCountryId { get; set; }
+        /*[ForeignKey("CountryProfile")]
+        public int RecipentCountryId { get; set; }*/
+        public CountryProfile RecipientCountry { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowarPhotorequest.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowarPhotorequest.cs
@@ -19,17 +19,19 @@ namespace PhotoKingdomAPI.Models
         public DateTime DenialDate { get; set; }
 
         [Required]
-        //public int CountryPhotowarId { get; set; }
+        public int CountryPhotowarId { get; set; }
+
+        [Required]
+        [ForeignKey("Resident")]
+        public int RequestingResidentId { get; set; }
+
+        [Required]
+        [ForeignKey("Resident")]
+        public int RecipientResidentId { get; set; }
+
+        // navigations
         public CountryPhotowar CountryPhotowar { get; set; }
-
-        [Required]
-        /*[ForeignKey("Resident")]
-        public int RequestingResidentId { get; set; }*/
         public Resident RequestingResident { get; set; }
-
-        [Required]
-        /*[ForeignKey("Resident")]
-        public int RecipientResidentId { get; set; }*/
         public Resident RecipientResident { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowarPhotorequest.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowarPhotorequest.cs
@@ -19,14 +19,17 @@ namespace PhotoKingdomAPI.Models
         public DateTime DenialDate { get; set; }
 
         [Required]
-        public int CountryPhotowarId { get; set; }
+        //public int CountryPhotowarId { get; set; }
+        public CountryPhotowar CountryPhotowar { get; set; }
 
         [Required]
-        [ForeignKey("Resident")]
-        public int RequestingResidentId { get; set; }
+        /*[ForeignKey("Resident")]
+        public int RequestingResidentId { get; set; }*/
+        public Resident RequestingResident { get; set; }
 
         [Required]
-        [ForeignKey("Resident")]
-        public int RecipientResidentId { get; set; }
+        /*[ForeignKey("Resident")]
+        public int RecipientResidentId { get; set; }*/
+        public Resident RecipientResident { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowarRequestedphotoUpload.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowarRequestedphotoUpload.cs
@@ -14,11 +14,13 @@ namespace PhotoKingdomAPI.Models
         public int IsChosenCompetitor { get; set; }
 
         [Required]
-        //public int PhotoId { get; set; }
-        public Photo Photo { get; set; }
+        public int PhotoId { get; set; }
 
         [Required]
-        //public int CountryPhotowarPhotorequestId { get; set; }
+        public int CountryPhotowarPhotorequestId { get; set; }
+
+        // navigations
+        public Photo Photo { get; set; }
         public CountryPhotowarPhotorequest CountryPhotowarPhotorequest { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowarRequestedphotoUpload.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowarRequestedphotoUpload.cs
@@ -6,7 +6,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace PhotoKingdomAPI.Models
 {
-    public class CountryPhotowarRequestdphotoUpload
+    public class CountryPhotowarRequestedphotoUpload
     {
         public int Id { get; set; }
 
@@ -14,9 +14,11 @@ namespace PhotoKingdomAPI.Models
         public int IsChosenCompetitor { get; set; }
 
         [Required]
-        public int PhotoId { get; set; }
+        //public int PhotoId { get; set; }
+        public Photo Photo { get; set; }
 
         [Required]
-        public int CountryPhotowarPhotorequestId { get; set; }
+        //public int CountryPhotowarPhotorequestId { get; set; }
+        public CountryPhotowarPhotorequest CountryPhotowarPhotorequest { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowarUpload.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowarUpload.cs
@@ -15,10 +15,15 @@ namespace PhotoKingdomAPI.Models
         public int IsLoser { get; set; }
 
         [Required]
-        public int PhotoId { get; set; }
+        //public int PhotoId { get; set; }
+        public Photo Photo { get; set; }
 
         [Required]
-        public int CountryPhotowarId { get; set; }
+        //public int CountryPhotowarId { get; set; }
+        public CountryPhotowar CountryPhotowar { get; set; }
+
+        // Votes
+        public ICollection<Resident> ResidentVote { get; set; }
 
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowarUpload.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryPhotowarUpload.cs
@@ -8,6 +8,11 @@ namespace PhotoKingdomAPI.Models
 {
     public class CountryPhotowarUpload
     {
+        public CountryPhotowarUpload()
+        {
+            ResidentVotes = new List<Resident>();
+        }
+
         public int Id { get; set; }
 
         public int IsWinner { get; set; }
@@ -15,15 +20,16 @@ namespace PhotoKingdomAPI.Models
         public int IsLoser { get; set; }
 
         [Required]
-        //public int PhotoId { get; set; }
-        public Photo Photo { get; set; }
+        public int PhotoId { get; set; }
 
         [Required]
-        //public int CountryPhotowarId { get; set; }
-        public CountryPhotowar CountryPhotowar { get; set; }
+        public int CountryPhotowarId { get; set; }
 
-        // Votes
-        public ICollection<Resident> ResidentVote { get; set; }
+        // navigations
+        public Photo Photo { get; set; }
+        public CountryPhotowar CountryPhotowar { get; set; }
+        // Votes for this CountryPhotowarUpload
+        public ICollection<Resident> ResidentVotes { get; set; }
 
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryProfile.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryProfile.cs
@@ -11,9 +11,11 @@ namespace PhotoKingdomAPI.Models
         public int Id { get; set; }
 
         [Required]
-        public int CountryId { get; set; }
+        //public int CountryId { get; set; }
+        public Country Country { get; set; }
 
         [Required]
-        public int PhotoId { get; set; }
+        //public int PhotoId { get; set; }
+        public Photo Photo { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryProfile.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/CountryProfile.cs
@@ -11,11 +11,13 @@ namespace PhotoKingdomAPI.Models
         public int Id { get; set; }
 
         [Required]
-        //public int CountryId { get; set; }
-        public Country Country { get; set; }
+        public int CountryId { get; set; }
 
         [Required]
-        //public int PhotoId { get; set; }
+        public int PhotoId { get; set; }
+
+        // navigations
+        public Country Country { get; set; }
         public Photo Photo { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Photo.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Photo.cs
@@ -20,6 +20,8 @@ namespace PhotoKingdomAPI.Models
         [Required]
         public float Lng { get; set; }
 
-        public int ResidentId { get; set; }
+        [Required]
+        //public int ResidentId { get; set; }
+        public Resident Resident { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Photo.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Photo.cs
@@ -8,6 +8,15 @@ namespace PhotoKingdomAPI.Models
 {
     public class Photo
     {
+        public Photo()
+        {
+            AttractionPhotowarUploads = new List<AttractionPhotowarUpload>();
+            CountryPhotowarUploads = new List<CountryPhotowarUpload>();
+            ContinentPhotowarUploads = new List<ContinentPhotowarUpload>();
+            CountryPhotowarRequestedphotoUploads = new List<CountryPhotowarRequestedphotoUpload>();
+            ContinentPhotowarRequestedphotoUploads = new List<ContinentPhotowarRequestedphotoUpload>();
+        }
+
         public int Id { get; set; }
 
         [Required]
@@ -21,7 +30,19 @@ namespace PhotoKingdomAPI.Models
         public float Lng { get; set; }
 
         [Required]
-        //public int ResidentId { get; set; }
+        public int ResidentId { get; set; }
+
+        // navigation
+
         public Resident Resident { get; set; }
+        
+        // the Photowars this photo has participated in
+        public ICollection<AttractionPhotowarUpload> AttractionPhotowarUploads { get; set; }
+        public ICollection<CountryPhotowarUpload> CountryPhotowarUploads { get; set; }
+        public ICollection<ContinentPhotowarUpload> ContinentPhotowarUploads { get; set; }
+
+        // the PhotowarPhotorequests by leaders that this photo has uploaded for
+        public ICollection<CountryPhotowarRequestedphotoUpload> CountryPhotowarRequestedphotoUploads { get; set; }
+        public ICollection<ContinentPhotowarRequestedphotoUpload> ContinentPhotowarRequestedphotoUploads { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Ping.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Ping.cs
@@ -17,11 +17,13 @@ namespace PhotoKingdomAPI.Models
         public DateTime ExpiryDate { get; set; }
 
         [Required]
-        //public int ResidentId { get; set; }
-        public Resident Resident { get; set; }
+        public int ResidentId { get; set; }
 
         [Required]
-        //public int AttractionId { get; set; }
+        public int AttractionId { get; set; }
+
+        // navigations
+        public Resident Resident { get; set; }
         public Attraction Attraction { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Ping.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Ping.cs
@@ -17,9 +17,11 @@ namespace PhotoKingdomAPI.Models
         public DateTime ExpiryDate { get; set; }
 
         [Required]
-        public int ResidentId { get; set; }
+        //public int ResidentId { get; set; }
+        public Resident Resident { get; set; }
 
         [Required]
-        public int AttractionId { get; set; }
+        //public int AttractionId { get; set; }
+        public Attraction Attraction { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Province.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Province.cs
@@ -15,6 +15,7 @@ namespace PhotoKingdomAPI.Models
         public string Name { get; set; }
 
         [Required]
-        public int CountryId { get; set; }
+        //public int CountryId { get; set; }
+        public Country Country { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Province.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Province.cs
@@ -8,6 +8,11 @@ namespace PhotoKingdomAPI.Models
 {
     public class Province
     {
+        public Province()
+        {
+            Owners = new List<ResidentProvinceOwn>();
+        }
+
         public int Id { get; set; }
 
         [Required]
@@ -15,7 +20,12 @@ namespace PhotoKingdomAPI.Models
         public string Name { get; set; }
 
         [Required]
-        //public int CountryId { get; set; }
+        public int CountryId { get; set; }
+
+        // navigation
+
         public Country Country { get; set; }
+        // all the residents that owned this province
+        public ICollection<ResidentProvinceOwn> Owners { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Queue.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Queue.cs
@@ -14,11 +14,15 @@ namespace PhotoKingdomAPI.Models
         public DateTime QueueDate { get; set; }
 
         [Required]
-        //public int AttractionId { get; set; }
-        public Attraction Attraction { get; set; }
+        public int AttractionId { get; set; }
 
         [Required]
-        //public int AttractionPhotowarUploadId { get; set; }
+        public int AttractionPhotowarUploadId { get; set; }
+
+        // navigations
+
+        public Attraction Attraction { get; set; }
+        // the photo uploaded
         public AttractionPhotowarUpload AttractionPhotowarUpload { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Queue.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Queue.cs
@@ -14,9 +14,11 @@ namespace PhotoKingdomAPI.Models
         public DateTime QueueDate { get; set; }
 
         [Required]
-        public int AttractionId { get; set; }
+        //public int AttractionId { get; set; }
+        public Attraction Attraction { get; set; }
 
         [Required]
-        public int AttractionPhotowarUploadId { get; set; }
+        //public int AttractionPhotowarUploadId { get; set; }
+        public AttractionPhotowarUpload AttractionPhotowarUpload { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Resident.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Resident.cs
@@ -3,11 +3,30 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Web;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace PhotoKingdomAPI.Models
 {
     public class Resident
     {
+        public Resident()
+        {
+            Photos = new List<Photo>();
+            Pings = new List<Ping>();
+            AttractionPhotowarVotes = new List<AttractionPhotowarUpload>();
+            CountryPhotowarVotes = new List<CountryPhotowarUpload>();
+            ContinentPhotowarVotes = new List<ContinentPhotowarUpload>();
+            ResidentAttractionOwns = new List<ResidentAttractionOwn>();
+            ResidentCityOwns = new List<ResidentCityOwn>();
+            ResidentProvinceOwns = new List<ResidentProvinceOwn>();
+            ResidentCountryOwns = new List<ResidentCountryOwn>();
+            ResidentContinentOwns = new List<ResidentContinentOwn>();
+            RequestedCountryPhotowarPhotorequests = new List<CountryPhotowarPhotorequest>();
+            ReceivedCountryPhotowarPhotorequests = new List<CountryPhotowarPhotorequest>();
+            RequestedContinentPhotowarPhotorequests = new List<ContinentPhotowarPhotorequest>();
+            ReceivedContinentPhotowarPhotorequests = new List<ContinentPhotowarPhotorequest>();
+        }
+
         public int Id { get; set; }
 
         [Required]
@@ -33,12 +52,45 @@ namespace PhotoKingdomAPI.Models
         public string AvatarImagePath { get; set; }
 
         [Required]
-        //public int CityId { get; set; }
+        public int CityId { get; set; }
+
+        // navigations
+
+        // the city the Resident belongs to
         public City City { get; set; }
 
-        // Votes
-        public ICollection<AttractionPhotowarUpload> AttractionPhotowarVote { get; set; }
-        public ICollection<CountryPhotowarUpload> CountryPhotowarVote { get; set; }
-        public ICollection<ContinentPhotowarUpload> ContinentPhotowarVote { get; set; }
+        // Resident's photos
+        public ICollection<Photo> Photos { get; set; }
+
+        // Resident's pings
+        public ICollection<Ping> Pings { get; set; }
+
+        // the votes that the Resident has made
+        public ICollection<AttractionPhotowarUpload> AttractionPhotowarVotes { get; set; }
+        public ICollection<CountryPhotowarUpload> CountryPhotowarVotes { get; set; }
+        public ICollection<ContinentPhotowarUpload> ContinentPhotowarVotes { get; set; }
+
+        // all the "owns" this resident has had
+        public ICollection<ResidentAttractionOwn> ResidentAttractionOwns { get; set; }
+        public ICollection<ResidentCityOwn> ResidentCityOwns { get; set; }
+        public ICollection<ResidentProvinceOwn> ResidentProvinceOwns { get; set; }
+        public ICollection<ResidentCountryOwn> ResidentCountryOwns { get; set; }
+        public ICollection<ResidentContinentOwn> ResidentContinentOwns { get; set; }
+        
+        // the CountryPhotowarPhotorequests this resident has made to subordinates
+        [InverseProperty("RequestingResident")]
+        public ICollection<CountryPhotowarPhotorequest> RequestedCountryPhotowarPhotorequests { get; set; }
+        
+        // the CountryPhotowarPhotorequests this resident has received from the King/Queen
+        [InverseProperty("RecipientResident")]
+        public ICollection<CountryPhotowarPhotorequest> ReceivedCountryPhotowarPhotorequests { get; set; }
+        
+        // the ContinentPhotowarPhotorequests this resident has made to subordinates
+        [InverseProperty("RequestingResident")]
+        public ICollection<ContinentPhotowarPhotorequest> RequestedContinentPhotowarPhotorequests { get; set; }
+        
+        // the ContinentPhotowarPhotorequests this resident has received from the Emperor/Empress
+        [InverseProperty("RecipientResident")]
+        public ICollection<ContinentPhotowarPhotorequest> ReceivedContinentPhotowarPhotorequests { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Resident.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/Resident.cs
@@ -33,6 +33,12 @@ namespace PhotoKingdomAPI.Models
         public string AvatarImagePath { get; set; }
 
         [Required]
-        public int CityId { get; set; }
+        //public int CityId { get; set; }
+        public City City { get; set; }
+
+        // Votes
+        public ICollection<AttractionPhotowarUpload> AttractionPhotowarVote { get; set; }
+        public ICollection<CountryPhotowarUpload> CountryPhotowarVote { get; set; }
+        public ICollection<ContinentPhotowarUpload> ContinentPhotowarVote { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentAttractionOwn.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentAttractionOwn.cs
@@ -20,11 +20,13 @@ namespace PhotoKingdomAPI.Models
         public string Title { get; set; }
 
         [Required]
-        //public int ResidentId { get; set; }
-        public Resident Resident { get; set; }
+        public int ResidentId { get; set; }
 
         [Required]
-        //public int AttractionId { get; set; }
+        public int AttractionId { get; set; }
+
+        // navigations
+        public Resident Resident { get; set; }
         public Attraction Attraction { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentAttractionOwn.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentAttractionOwn.cs
@@ -20,9 +20,11 @@ namespace PhotoKingdomAPI.Models
         public string Title { get; set; }
 
         [Required]
-        public int ResidentId { get; set; }
+        //public int ResidentId { get; set; }
+        public Resident Resident { get; set; }
 
         [Required]
-        public int AttractionId { get; set; }
+        //public int AttractionId { get; set; }
+        public Attraction Attraction { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentCityOwn.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentCityOwn.cs
@@ -20,11 +20,13 @@ namespace PhotoKingdomAPI.Models
         public string Title { get; set; }
 
         [Required]
-        //public int ResidentId { get; set; }
-        public Resident Resident { get; set; }
+        public int ResidentId { get; set; }
 
         [Required]
-        //public int CityId { get; set; }
+        public int CityId { get; set; }
+
+        // navigations
+        public Resident Resident { get; set; }
         public City City { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentCityOwn.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentCityOwn.cs
@@ -20,9 +20,11 @@ namespace PhotoKingdomAPI.Models
         public string Title { get; set; }
 
         [Required]
-        public int ResidentId { get; set; }
+        //public int ResidentId { get; set; }
+        public Resident Resident { get; set; }
 
         [Required]
-        public int CityId { get; set; }
+        //public int CityId { get; set; }
+        public City City { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentContinentOwn.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentContinentOwn.cs
@@ -20,11 +20,13 @@ namespace PhotoKingdomAPI.Models
         public string Title { get; set; }
 
         [Required]
-        //public int ResidentId { get; set; }
-        public Resident Resident { get; set; }
+        public int ResidentId { get; set; }
 
         [Required]
-        //public int ContinentId { get; set; }
+        public int ContinentId { get; set; }
+
+        // navigations
+        public Resident Resident { get; set; }
         public Continent Continent { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentContinentOwn.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentContinentOwn.cs
@@ -20,9 +20,11 @@ namespace PhotoKingdomAPI.Models
         public string Title { get; set; }
 
         [Required]
-        public int ResidentId { get; set; }
+        //public int ResidentId { get; set; }
+        public Resident Resident { get; set; }
 
         [Required]
-        public int ContinentId { get; set; }
+        //public int ContinentId { get; set; }
+        public Continent Continent { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentCountryOwn.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentCountryOwn.cs
@@ -20,11 +20,13 @@ namespace PhotoKingdomAPI.Models
         public string Title { get; set; }
 
         [Required]
-        //public int ResidentId { get; set; }
-        public Resident Resident { get; set; }
+        public int ResidentId { get; set; }
 
         [Required]
-        //public int CountryId { get; set; }
+        public int CountryId { get; set; }
+
+        // navigations
+        public Resident Resident { get; set; }
         public Country Country { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentCountryOwn.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentCountryOwn.cs
@@ -20,9 +20,11 @@ namespace PhotoKingdomAPI.Models
         public string Title { get; set; }
 
         [Required]
-        public int ResidentId { get; set; }
+        //public int ResidentId { get; set; }
+        public Resident Resident { get; set; }
 
         [Required]
-        public int CountryId { get; set; }
+        //public int CountryId { get; set; }
+        public Country Country { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentProvinceOwn.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentProvinceOwn.cs
@@ -20,9 +20,11 @@ namespace PhotoKingdomAPI.Models
         public string Title { get; set; }
 
         [Required]
-        public int ResidentId { get; set; }
+        //public int ResidentId { get; set; }
+        public Resident Resident { get; set; }
 
         [Required]
-        public int ProvinceId { get; set; }
+        //public int ProvinceId { get; set; }
+        public Province Province { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentProvinceOwn.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/ResidentProvinceOwn.cs
@@ -20,11 +20,13 @@ namespace PhotoKingdomAPI.Models
         public string Title { get; set; }
 
         [Required]
-        //public int ResidentId { get; set; }
-        public Resident Resident { get; set; }
+        public int ResidentId { get; set; }
 
         [Required]
-        //public int ProvinceId { get; set; }
+        public int ProvinceId { get; set; }
+
+        // navigations
+        public Resident Resident { get; set; }
         public Province Province { get; set; }
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/VoteAttractionPhotowarUpload.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/VoteAttractionPhotowarUpload.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿/*using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
@@ -16,4 +16,4 @@ namespace PhotoKingdomAPI.Models
         public int AttractionPhotowarUploadId { get; set; }
 
     }
-}
+}*/

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/VoteContinentPhotowarUpload.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/VoteContinentPhotowarUpload.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿/*using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
@@ -15,4 +15,4 @@ namespace PhotoKingdomAPI.Models
         [Key, Column(Order = 1)]
         public int ContinentPhotowarUploadId { get; set; }
     }
-}
+}*/

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/VoteCountryPhotowarUpload.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/DesignModels/VoteCountryPhotowarUpload.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿/*using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
@@ -15,4 +15,4 @@ namespace PhotoKingdomAPI.Models
         [Key, Column(Order = 1)]
         public int CountryPhotowarUploadId { get; set; }
     }
-}
+}*/

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Models/IdentityModels.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Models/IdentityModels.cs
@@ -39,7 +39,7 @@ namespace PhotoKingdomAPI.Models
         public DbSet<Country> Countries { get; set; }
         public DbSet<CountryPhotowar> CountryPhotowars { get; set; }
         public DbSet<CountryPhotowarPhotorequest> CountryPhotowarPhotorequests { get; set; }
-        public DbSet<CountryPhotowarRequestdphotoUpload> CountryPhotowarRequestdphotoUploads { get; set; }
+        public DbSet<CountryPhotowarRequestedphotoUpload> CountryPhotowarRequestdphotoUploads { get; set; }
         public DbSet<CountryPhotowarUpload> CountryPhotowarUploads { get; set; }
         public DbSet<CountryProfile> CountryProfiles { get; set; }
         public DbSet<Photo> Photos { get; set; }
@@ -52,9 +52,9 @@ namespace PhotoKingdomAPI.Models
         public DbSet<ResidentContinentOwn> ResidentContinentOwns { get; set; }
         public DbSet<ResidentCountryOwn> ResidentCountryOwns { get; set; }
         public DbSet<ResidentProvinceOwn> ResidentProvinceOwns { get; set; }
-        public DbSet<VoteAttractionPhotowarUpload> VoteAttractionPhotowarUploads { get; set; }
-        public DbSet<VoteContinentPhotowarUpload> VoteContinentPhotowarUploads { get; set; }
-        public DbSet<VoteCountryPhotowarUpload> VoteCountryPhotowarUploads { get; set; }
+        //public DbSet<VoteAttractionPhotowarUpload> VoteAttractionPhotowarUploads { get; set; }
+        //public DbSet<VoteContinentPhotowarUpload> VoteContinentPhotowarUploads { get; set; }
+        //public DbSet<VoteCountryPhotowarUpload> VoteCountryPhotowarUploads { get; set; }
 
         public static ApplicationDbContext Create()
         {

--- a/PhotoKingdomAPI/PhotoKingdomAPI/PhotoKingdomAPI.csproj
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/PhotoKingdomAPI.csproj
@@ -223,7 +223,7 @@
     <Compile Include="Controllers\ViewModels\ContinentProfile_vm.cs" />
     <Compile Include="Controllers\ViewModels\Continent_vm.cs" />
     <Compile Include="Controllers\ViewModels\CountryPhotowarPhotorequest_vm.cs" />
-    <Compile Include="Controllers\ViewModels\CountryPhotowarRequestdphotoUpload_vm.cs" />
+    <Compile Include="Controllers\ViewModels\CountryPhotowarRequestedphotoUpload_vm.cs" />
     <Compile Include="Controllers\ViewModels\CountryPhotowarUpload_vm.cs" />
     <Compile Include="Controllers\ViewModels\CountryPhotowar_vm.cs" />
     <Compile Include="Controllers\ViewModels\CountryProfile_vm.cs" />


### PR DESCRIPTION
- Added navigation properties for all design models so that we can work with an object's associated objects
- Removed (well, commented-out only, in case we need to keep) the join tables (VoteAttractionPhotowarUpload, VoteContinentPhotowarUpload, VoteCountryPhotowarUpload) and just set the many-to-many associations through the parent tables to let Code First Migrations take care of doing the many-to-many association and let it create the join tables itself
- the navigation properties are based on all the associations we would need in our app's data, based on the Use Case Specifications I looked through in our PID
