### PR TITLE
Added properties to AttractionPhotowar API for Resident Voting Info

### DIFF
--- a/PhotoKingdomAPI/PhotoKingdomAPI/Controllers/AttractionPhotowarsController.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Controllers/AttractionPhotowarsController.cs
@@ -40,13 +40,13 @@ namespace PhotoKingdomAPI.Controllers
 
         // GET: api/AttractionPhotowars/{id}/details
         [Route("{id:int}/details")]
-        public IHttpActionResult GetAttractionPhotowarDetails(int? id)
+        public IHttpActionResult GetAttractionPhotowarDetails(int? id, int? residentId = null)
         {
             // Determine whether we can continue
             if (!id.HasValue) { return NotFound(); }
 
             // Fetch the object, so that we can inspect its value
-            var o = m.AttractionPhotowarGetByIdWithDetails(id.Value);
+            var o = m.AttractionPhotowarGetByIdWithDetails(id.Value, residentId);
 
             if (o == null)
             {

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Controllers/Manager.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Controllers/Manager.cs
@@ -835,10 +835,54 @@ namespace PhotoKingdomAPI.Controllers
             }
         }
 
-        public AttractionPhotowarWithDetails AttractionPhotowarGetByIdWithDetails(int id)
+        // Gets AttractionPhotowarWithDetails by Id, and if residentId passed in, identifies whether Resident has voted or is part of the photowar
+        public AttractionPhotowarWithDetails AttractionPhotowarGetByIdWithDetails(int id, int? residentId)
         {
             var a = ds.AttractionPhotowars.Include("Attraction").Include("AttractionPhotowarUploads.ResidentVotes").Include("AttractionPhotowarUploads.Photo.Resident").SingleOrDefault(o => o.Id == id);
-            return (a == null) ? null : mapper.Map<AttractionPhotowarWithDetails>(a);
+            var attraction_vm = mapper.Map<AttractionPhotowarWithDetails>(a);
+
+            if (residentId.HasValue)
+            {
+                var resident = ds.Residents.Find(residentId.Value);
+                if(resident != null)
+                {
+                    var uploads = a.AttractionPhotowarUploads;
+                    foreach(var upload in uploads)
+                    {
+                        if(upload.Photo.ResidentId == residentId.Value)
+                        {
+                            // photo belongs to Resident - set flag true
+                            attraction_vm.residentInPhotowar = 1;
+                            break; // break out of loop - Resident not allowed to vote because Resident part of photowar
+                        } else
+                        {
+                            var votes = upload.ResidentVotes;
+                            var upload_vm = attraction_vm.AttractionPhotowarUploads.Single(u => u.Id == upload.Id);
+                            if (votes.Contains(resident))
+                            {
+                                // Resident has voted for this photo - set flag true
+                                upload_vm.residentHasVoted = 1;
+                                continue;
+                            } else
+                            {
+                                // Resident hasn't voted for this photo - set flag from null to false
+                                upload_vm.residentHasVoted = 0;
+                            }
+                        }
+                    }
+
+                    // if Resident doesn't own any photos, set flag from null to false
+                    if(attraction_vm.residentInPhotowar != 1)
+                    {
+                        attraction_vm.residentInPhotowar = 0;
+                    }
+                } else
+                {
+                    throw new Exception("Resident with Id " + residentId.Value + " not found!");
+                }
+            }
+            
+            return attraction_vm;
         }
         #endregion AttractionPhotowar
 

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Controllers/ViewModels/AttractionPhotowarUpload_vm.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Controllers/ViewModels/AttractionPhotowarUpload_vm.cs
@@ -38,9 +38,16 @@ namespace PhotoKingdomAPI.Controllers
 
     public class AttractionPhotowarUploadForPhotowar : AttractionPhotowarUploadBase
     {
+        public AttractionPhotowarUploadForPhotowar()
+        {
+            residentHasVoted = -1; // null
+        }
         public PhotoBase Photo { get; set; }
         public string PhotoResidentUserName { get; set; }
         public string PhotoResidentAvatarImagePath { get; set; }
         public int ResidentVotesCount { get; set; }
+
+        // flag indicating whether signed-in Resident has already voted for this photo
+        public int residentHasVoted;
     }
 }

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Controllers/ViewModels/AttractionPhotowar_vm.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Controllers/ViewModels/AttractionPhotowar_vm.cs
@@ -34,9 +34,16 @@ namespace PhotoKingdomAPI.Controllers
 		public AttractionPhotowarWithDetails()
 		{
 			AttractionPhotowarUploads = new List<AttractionPhotowarUploadForPhotowar>();
+            residentInPhotowar = -1; // default null
 		}
 		public AttractionBase Attraction { get; set; }
 		// the two photos uploaded for this PhotoWar
 		public IEnumerable<AttractionPhotowarUploadForPhotowar> AttractionPhotowarUploads { get; set; }
+
+        // Additional information for Voting
+
+        // whether Resident's own photo is in this photowar
+        public int residentInPhotowar;
 	}
+
 }


### PR DESCRIPTION
Modified AttractionPhotowar Details API to allow client to check whether a Resident is part of the photowar, and whether Resident has already voted to any of the photos in the Photowar.