### PR TITLE
Class and method fix

### DIFF
--- a/PhotoKingdomAPI/PhotoKingdomAPI/Controllers/Manager.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Controllers/Manager.cs
@@ -1674,7 +1674,8 @@ namespace PhotoKingdomAPI.Controllers
 
             var attraction = mapper.Map<AttractionWithDetails>(a);
 
-            var photowars = a.AttractionPhotowars.OrderByDescending(p => p.EndDate).ToArray();
+            // get photowars that have ended already
+            var photowars = a.AttractionPhotowars.Where(p => p.EndDate < DateTime.Now).OrderByDescending(p => p.EndDate).ToArray();
             if (photowars.Length > 0)
             {
                 var winningUpload = photowars[0].AttractionPhotowarUploads.SingleOrDefault(u => u.IsWinner == 1);

--- a/PhotoKingdomAPI/PhotoKingdomAPI/Controllers/ViewModels/Photo_vm.cs
+++ b/PhotoKingdomAPI/PhotoKingdomAPI/Controllers/ViewModels/Photo_vm.cs
@@ -50,4 +50,13 @@ namespace PhotoKingdomAPI.Controllers
 		public IEnumerable<CountryPhotowarRequestedphotoUploadBase> CountryPhotowarRequestedphotoUploads { get; set; }
 		public IEnumerable<ContinentPhotowarRequestedphotoUploadBase> ContinentPhotowarRequestedphotoUploads { get; set; }
 	}
+
+    // Photo with info needed for Winning Photos gallery for an attraction
+    public class PhotoWinning : PhotoBase
+    {
+        public String ResidentUserName { get; set; }
+        public String ResidentAvatarImagePath { get; set; }
+        public int Votes { get; set; }
+        public DateTime WinningDate { get; set; }
+    }
 }


### PR DESCRIPTION
- added the missing WinningPhoto class
- modified method in attractionGetByGooglePlaceIdWithDetails to make sure that the imagepath is from a photowar that has already ended and already has a winner. Before, it was including even photowar that is ongoing, and since there is no winner, it was returning null for image path for attractions that have an ongoing photowar. 